### PR TITLE
Added checkConnection function

### DIFF
--- a/src/components/ROSContext.js
+++ b/src/components/ROSContext.js
@@ -5,6 +5,7 @@ const rosObj = {
   ROS: null,
   url: "ws://localhost:9090",
   isConnected: false,
+  ROSConfirmedConnected: false,
   autoconnect: false,
   topics: [],
   listeners: [],


### PR DESCRIPTION
(disregard the name of the branch!!)

As a way to address #40.
Basically ```ros.isConnected``` is set once and in an untimely manner (so if you want to check if it was connected, the check may not be valid for a spell). Once it is set, nothing is looking to check if ```ros.ROS.isConnected``` is ever true again.

this basically adds that functionality.
adds ```ROSConfirmedConnected``` that is set false when there is an connection attempt, then ```ros.isConnected``` is set true when connected (as is currently), however a call to ```checkConnection``` will then confirm that ```ros.ROS.isConnected``` is still true... once it is confirmed that ```ros.ROS.isConnected``` is true, then ```ROSConfirmedConnected``` and future calls to ```checkConnection``` will then set ```ros.isConnected``` to false